### PR TITLE
BLD: only allow POST, check for params in api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,16 +1,21 @@
 # Using the Python 3.9.1 image as it is a requirement for Tensorflow.
 FROM python:3.9.1
 
+# Change working directory (will create if it does not exist)
 WORKDIR /flask
 
-# Copy application files to the container image.
-ADD . /flask
-
-# Exposing 8080 because it is the port used for the API
-EXPOSE 8080
+# Copy list of required dependecies to the container image.
+ADD requirements.txt /flask
 
 # Install all application dependencies
 RUN pip install -r requirements.txt
 
+# Copy source code files
+ADD api.py /flask
+ADD templates /flask
+
+# Exposing 8080 because it is the port used for the API
+EXPOSE 8080
+
 # Run the web service on container startup.
-CMD [ "python", "flasksample.py" ]
+CMD [ "python", "api.py" ]

--- a/api/api.py
+++ b/api/api.py
@@ -24,16 +24,14 @@ def welcome():
     return render_template("index.html")
 
 
-@app.route('/detect', methods=['GET', 'POST'])
+@app.route('/detect', methods=['POST'])
 def detect():
     # Model loaded from https://huggingface.co/cardiffnlp/twitter-roberta-base-offensive/tree/main
-    thejson = {}
-    if request.method == "POST":
-        thejson = request.json
+    thejson = request.json
+    if 'text' in thejson:
         thejson['result'] = process(thejson['text'])
-    else: 
-        thejson['text'] = "Good night 😊"
-        thejson['result'] = process(thejson['text'])
+    else:
+        return "Invalid Parameters", 400
         
     return thejson
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ In a new terminal tab `cd` into the client folder and and run the following comm
 Build the API with docker by running 
 
 ```bash
-docker build --pull --rm -f "api/Dockerfile" -t kindly_api:latest "api"
+docker build -f "api/Dockerfile" -t kindly_api:latest "api"
 ```
 
 A container image of this API is also found on [Dockerhub](https://hub.docker.com/r/nathanfletcher/kindly_api)
@@ -37,7 +37,7 @@ A container image of this API is also found on [Dockerhub](https://hub.docker.co
 Build the demo client with docker by running 
 
 ```bash
-docker build --pull --rm -f "client/Dockerfile" -t kindly_client:latest "client"
+docker build -f "client/Dockerfile" -t kindly_client:latest "client"
 ```
 
 A container image of the client is also found on [Dockerhub](https://hub.docker.com/r/nathanfletcher/kindly_client)


### PR DESCRIPTION
Incremental improvements:
* If `/detect` only works with POST, only allow POST. Returns `405 Method Not Allowed` for GET
* Checks for the existence of `text` in query params, otherwise returns `400 Bad Request` with **Invalid Parameters** message
* Reorganized order of statements in `api/Dockerfile` to take advantage of caching in the image build. By installing dependencies first, and copying the code later, any changes in the build only take about 1 second for the docker image to rebuild
* Updated the documentation to remove the "caching removal `--rm`" from the build command, and removed `--pull` to optimize for build times at developer time