### PR TITLE
BLD: cache the model into docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 client/node_modules
 client/.nuxt
+api/model

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,6 +10,15 @@ ADD requirements.txt /flask
 # Install all application dependencies
 RUN pip install -r requirements.txt
 
+# Add code to cache ML model inside image
+ADD get_model.py /flask
+
+# Download model into ./model
+RUN python get_model.py
+
+# Download ML mappings
+RUN curl -LJ https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/datasets/offensive/mapping.txt -o model/mapping.txt
+
 # Copy source code files
 ADD api.py /flask
 ADD templates /flask/templates

--- a/api/api.py
+++ b/api/api.py
@@ -60,25 +60,23 @@ def process(inputText):
     # Tasks:
     # emoji, emotion, hate, irony, offensive, sentiment
     # stance/abortion, stance/atheism, stance/climate, stance/feminist, stance/hillary
-    task = 'offensive'
+
     # MODEL = AutoModelForSequenceClassification.from_pretrained("cardiffnlp/twitter-roberta-base-offensive")
     # tokenizer = AutoTokenizer.from_pretrained("cardiffnlp/twitter-roberta-base-offensive")
     # download label mapping
     labels = []
-    mapping_link = f"https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/datasets/{task}/mapping.txt"
-    with urllib.request.urlopen(mapping_link) as f:
-        html = f.read().decode('utf-8').split("\n")
+    mapping_link = f"model/mapping.txt"
+    with open(mapping_link) as f:
+        html = f.read().split("\n")
         csvreader = csv.reader(html, delimiter='\t')
     labels = [row[1] for row in csvreader if len(row) > 1]
 
     # PT
-    model = AutoModelForSequenceClassification.from_pretrained(
-        "cardiffnlp/twitter-roberta-base-offensive")
+    model = AutoModelForSequenceClassification.from_pretrained('./model')
     # model.save_pretrained(MODEL)
     text = inputText
     text = preprocess(text)
-    tokenizer = AutoTokenizer.from_pretrained(
-        "cardiffnlp/twitter-roberta-base-offensive")
+    tokenizer = AutoTokenizer.from_pretrained('./model')
     encoded_input = tokenizer(text, return_tensors='pt')
     output = model(**encoded_input)
 

--- a/api/get_model.py
+++ b/api/get_model.py
@@ -1,0 +1,20 @@
+from transformers import AutoModelForQuestionAnswering, AutoTokenizer
+
+def get_model(model):
+  """Loads model from Hugginface model hub"""
+  try:
+    model = AutoModelForQuestionAnswering.from_pretrained(model)
+    model.save_pretrained('./model')
+  except Exception as e:
+    raise(e)
+
+def get_tokenizer(tokenizer):
+  """Loads tokenizer from Hugginface model hub"""
+  try:
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+    tokenizer.save_pretrained('./model')
+  except Exception as e:
+    raise(e)
+
+get_model('cardiffnlp/twitter-roberta-base-offensive')
+get_tokenizer('cardiffnlp/twitter-roberta-base-offensive')

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,19 @@ Please make sure that your development environment has the following prerequisit
 
 ## Running Locally
 
-From the root of the application, run the python server using the following command `python api/flasksample.py`
+From the `api/` folder:
+
+1. First download a local copy of the ML model:
+
+```bash
+python get_model.py
+``` 
+
+2. Run the python server using the following command:
+
+```bash
+python api/flasksample.py
+```
 
 In a new terminal tab `cd` into the client folder and and run the following commands
 - `npm i`


### PR DESCRIPTION
Fix #17 

Based on the information found [here](https://towardsdatascience.com/serverless-bert-with-huggingface-aws-lambda-and-docker-4a0214c77a6f), this PR accomplishes the following:

- Downloads the `mappings.txt` file using curl during image build
- Opens the local file `mappings.txt` instead of fetching it from a remote location during runtime
- Adds new python file `get_model.py` which downloads the model into local folder `./model`
- Adds `./model` to `.gitignore`
- Instructs `api.py` to use locally cached ML model instead of fetching it remotely during runtime