### PR TITLE
BUG: get the right model!

### DIFF
--- a/api/get_model.py
+++ b/api/get_model.py
@@ -1,9 +1,9 @@
-from transformers import AutoModelForQuestionAnswering, AutoTokenizer
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 def get_model(model):
   """Loads model from Hugginface model hub"""
   try:
-    model = AutoModelForQuestionAnswering.from_pretrained(model)
+    model = AutoModelForSequenceClassification.from_pretrained(model)
     model.save_pretrained('./model')
   except Exception as e:
     raise(e)


### PR DESCRIPTION
Fixes a bug introduced in #20, where there was a mismatch between the model that was cached and the one that the API is using. The mismatch has been corrected.