### PR TITLE
MAINT: smaller docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,14 @@
 # Using the Python 3.9.1 image as it is a requirement for Tensorflow.
-FROM python:3.9.1
+FROM tensorflow/tensorflow:2.5.1
 
 # Change working directory (will create if it does not exist)
 WORKDIR /flask
 
 # Copy list of required dependecies to the container image.
-ADD requirements.txt /flask
+ADD requirements.docker.txt /flask
 
 # Install all application dependencies
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.docker.txt
 
 # Add code to cache ML model inside image
 ADD get_model.py /flask

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using the Python 3.9.1 image as it is a requirement for Tensorflow.
-FROM tensorflow/tensorflow:2.5.1
+FROM tensorflow/tensorflow:2.6.0
 
 # Change working directory (will create if it does not exist)
 WORKDIR /flask

--- a/api/requirements.docker.txt
+++ b/api/requirements.docker.txt
@@ -1,0 +1,4 @@
+flask==2.0.1
+torch==1.9.0
+transformers==4.9.1
+waitress==2.0.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,7 +11,7 @@ numpy==1.19.5
 pandas==1.3.1
 scikit-learn==0.24.2
 scipy==1.7.0
-tensorflow==2.5.1
+tensorflow==2.6.0
 torch==1.9.0
 torchvision==0.10.0
 transformers==4.9.1


### PR DESCRIPTION
This PR accomplishes the creation of a smaller image container for `API` by using the optimized `tensorflow` base image instead of the generic `python:3.9.1`. In my local machine, the size was reduced from **6.87GB** to **4.96GB**.

An attempt was made to start with the much smaller `python:3.9.1-alpine` base image, but tensorflow would not install: pip complains that it cannot find the package, and when using the wheel directly (such as  https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.5.1-cp39-cp39-manylinux2010_x86_64.whl) it complains that this wheel is not supported for this platform