### PR TITLE
Http header requirement for env variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+TOKEN_KEYS = '{"aasdf1234":"third_party1", "a]gghrydf1234":"third_party1", "klasjdflkja" : "third_party2"}'

--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,1 @@
-TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_2", "klasjdflkja" : "third_party_3"}'
+TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_1", "klasjdflkja" : "third_party_3"}'

--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,1 @@
-TOKEN_KEYS = '{"aasdf1234":"third_party1", "a]gghrydf1234":"third_party1", "klasjdflkja" : "third_party2"}'
+TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_2", "klasjdflkja" : "third_party_3"}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 client/node_modules
 client/.nuxt
 api/model
+.env

--- a/api/api.py
+++ b/api/api.py
@@ -20,11 +20,11 @@ app = Flask(__name__)
 
 @app.route('/', methods=['GET', 'POST'])
 def apiGlossary():
+    checkHeaders()
     glossary = {
         "detect": "/detect",
         # "train": "/train" #this is yet to be completed
     }
-    checkHeaders()
     return glossary
 
 @app.route('/test-ui', methods=['GET', 'POST'])
@@ -34,6 +34,7 @@ def welcome():
 
 @app.route('/detect', methods=['POST'])
 def detect():
+    checkHeaders()
     # Model loaded from https://huggingface.co/cardiffnlp/twitter-roberta-base-offensive/tree/main
     thejson = request.json
     if 'text' in thejson:
@@ -45,6 +46,7 @@ def detect():
 
 @app.route("/train")
 def train():
+    checkHeaders()
     train_path = request.args.get("data", "data/train.csv")
     epochs = request.args.get("epochs", 10)
     emotion.train(train_path, epochs)

--- a/api/api.py
+++ b/api/api.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask import jsonify
 from flask import request
 from flask import abort
-import flask
+from flask import request as flask_request
 import numpy as np
 import urllib
 import csv
@@ -60,7 +60,7 @@ def preprocess(text):
     return " ".join(new_text)
 
 def checkHeaders():
-    headers = flask.request.headers
+    headers = flask_request.headers
     if os.getenv('TOKEN_KEYS') is not None:
         tokens = json.loads(os.getenv('TOKEN_KEYS'))
         if headers.get("Authorization") is not None:

--- a/api/api.py
+++ b/api/api.py
@@ -1,13 +1,18 @@
 from flask import Flask
 from flask import jsonify
 from flask import request
+from flask import abort
+import flask
 import numpy as np
 import urllib
 import csv
 import os
+from dotenv import load_dotenv
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 from flask import render_template
 from waitress import serve
+import json
+load_dotenv()
 
 REMOTE_MAPPING = 'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/datasets/offensive/mapping.txt'
 
@@ -19,6 +24,7 @@ def apiGlossary():
         "detect": "/detect",
         # "train": "/train" #this is yet to be completed
     }
+    checkHeaders()
     return glossary
 
 @app.route('/test-ui', methods=['GET', 'POST'])
@@ -50,6 +56,26 @@ def preprocess(text):
         t = 'http' if t.startswith('http') else t
         new_text.append(t)
     return " ".join(new_text)
+
+def checkHeaders():
+    headers = flask.request.headers
+    print(os.getenv('TOKEN_KEYS'))
+    print("Request headers:\n" + str(headers))
+    if os.getenv('TOKEN_KEYS') is not None:
+        print("keys  dey")
+        tokens = json.loads(os.getenv('TOKEN_KEYS'))
+        if headers.get("Authorization") is not None:
+            print("Auth present")
+            print(os.getenv('TOKEN_KEYS'))
+            extractBearerToken = headers['Authorization']
+            token = extractBearerToken.split(" ")
+            if tokens.get(token[1]) is None:
+                abort(403)
+        else:
+            print("suppose to abort")
+            abort(403)
+
+
 
 
 def softmax(x):

--- a/api/api.py
+++ b/api/api.py
@@ -59,23 +59,15 @@ def preprocess(text):
 
 def checkHeaders():
     headers = flask.request.headers
-    print(os.getenv('TOKEN_KEYS'))
-    print("Request headers:\n" + str(headers))
     if os.getenv('TOKEN_KEYS') is not None:
-        print("keys  dey")
         tokens = json.loads(os.getenv('TOKEN_KEYS'))
         if headers.get("Authorization") is not None:
-            print("Auth present")
-            print(os.getenv('TOKEN_KEYS'))
             extractBearerToken = headers['Authorization']
             token = extractBearerToken.split(" ")
             if tokens.get(token[1]) is None:
                 abort(403)
         else:
-            print("suppose to abort")
             abort(403)
-
-
 
 
 def softmax(x):

--- a/api/requirements.docker.txt
+++ b/api/requirements.docker.txt
@@ -1,4 +1,5 @@
 flask==2.0.1
+python-dotenv==0.19.0
 torch==1.9.0
 transformers==4.9.1
 waitress==2.0.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,6 +9,7 @@ matplotlib==3.4.2
 mwparserfromhell==0.6.2
 numpy==1.19.5
 pandas==1.3.1
+python-dotenv==0.19.0
 scikit-learn==0.24.2
 scipy==1.7.0
 tensorflow==2.6.0

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,51 @@ Please make sure that your development environment has the following prerequisit
     - `pip install -r requirements.txt`
     - Install pytorch by going to (their website)[https://pytorch.org/get-started/locally/] to know how to do it with your operating system. However, for this mac configuration in this project you can use `pip` by running `pip install torch torchvision`
 
+
+
+### Environment Variables
+You can set Authorization headers using environment variables
+The current sample template can be found in the `.env.template` file.
+The key used is `TOKEN_KEYS` and it is a JSON object of token keys with a value of who owns that key as seen below.
+
+```
+TOKEN_KEYS = '{"aasdf1234":"third_party1", "a]gghrydf1234":"third_party1", "klasjdflkja" : "third_party2"}'
+```
+
+If this environment variable is set, always make sure that all requests to the api have an `Authorization` header with `'Bearer <token>'` value.
+
+Below is an example using Axios in NodeJS
+```
+var axios = require('axios');
+var data = JSON.stringify({
+  "text": "I love you so much"
+});
+
+var config = {
+  method: 'post',
+  url: 'localhost:8080/detect',
+  headers: { 
+    'Authorization': 'Bearer aasdf1234', 
+    'Content-Type': 'application/json'
+  },
+  data : data
+};
+
+axios(config)
+.then(function (response) {
+  console.log(JSON.stringify(response.data));
+})
+.catch(function (error) {
+  console.log(error);
+});
+
+```
+
+Unauthorized keys in the request will return a `403`
+
+*For developmental purposes, the API will still run if this environment variable is not set when running locally as described below*
 ## Running Locally
+
 
 From the `api/` folder:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,21 +10,21 @@ Please make sure that your development environment has the following prerequisit
     - `pip install -r requirements.txt`
     - Install pytorch by going to (their website)[https://pytorch.org/get-started/locally/] to know how to do it with your operating system. However, for this mac configuration in this project you can use `pip` by running `pip install torch torchvision`
 
-
-
 ### Environment Variables
+
 You can set Authorization headers using environment variables
 The current sample template can be found in the `.env.template` file.
 The key used is `TOKEN_KEYS` and it is a JSON object of token keys with a value of who owns that key as seen below.
 
 ```
-TOKEN_KEYS = '{"aasdf1234":"third_party1", "a]gghrydf1234":"third_party1", "klasjdflkja" : "third_party2"}'
+TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_2", "klasjdflkja" : "third_party_3"}'
 ```
 
 If this environment variable is set, always make sure that all requests to the api have an `Authorization` header with `'Bearer <token>'` value.
 
 Below is an example using Axios in NodeJS
-```
+
+```js
 var axios = require('axios');
 var data = JSON.stringify({
   "text": "I love you so much"
@@ -50,11 +50,11 @@ axios(config)
 
 ```
 
-Unauthorized keys in the request will return a `403`
+Unauthorized keys in the request will return a `403` HTTP error.
 
-*For developmental purposes, the API will still run if this environment variable is not set when running locally as described below*
+*Note: For developmental purposes, the API will still run if this environment variable is not set when running locally as described below*
+
 ## Running Locally
-
 
 From the `api/` folder:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,6 +50,17 @@ axios(config)
 
 ```
 
+And the same example using curl:
+```bash
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer aasdf1234" \
+  http://localhost:8080/detect \
+  -d '{"text":"I love you so much"}'
+
+```
+
 Unauthorized keys in the request will return a `403` HTTP error.
 
 *Note: For developmental purposes, the API will still run if this environment variable is not set when running locally as described below*

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@ The current sample template can be found in the `.env.template` file.
 The key used is `TOKEN_KEYS` and it is a JSON object of token keys with a value of who owns that key as seen below.
 
 ```
-TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_2", "klasjdflkja" : "third_party_3"}'
+TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_1", "klasjdflkja" : "third_party_3"}'
 ```
 
 If this environment variable is set, always make sure that all requests to the api have an `Authorization` header with `'Bearer <token>'` value.


### PR DESCRIPTION
This PR fixes #25 


- [x] Modify api.py Flask code to check for the existence of an `Authorization` HTTP header
- [x] Extract the token from the HTTP header
- [x] Compare the token received with a list of authorized tokens
- [x] Accept the request is authorized, or reject with a `403` HTTP error otherwise
- [x] Configure the list of authorized tokens from a multi-value attribute passed as an environment variable.
- [x] If no env variable is passed, accept all requests (to reduce friction in running the app locally)
- [x] Document this implementation 