### PR TITLE
Ignore model folder

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -1,6 +1,0 @@
-### What does this folder do?
-
-This folder holds dowloaded tokenizer and model files.
-As one of the first steps in setting up this project, it is necessary to run python `api/get_model.py`.
-The script downloads tokenizer data, mappings and the model into this folder.
-The code from the `api` folder will reference these items during api calls.


### PR DESCRIPTION
This PR closes #42 

During my documentation process, I realized that this folder should be ignored.
This would make sure that the folder exists when `python api/get_model.py` is run during the initial setup of the project.
