### PR TITLE
BUG: removed unchecked blocking condition

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -19,7 +19,7 @@ REMOTE_MAPPING = 'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/da
 
 app = Flask(__name__)
 
-allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net""https://kindly-api.azurewebsites.net"]
+allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net"]
 
 cors = CORS(app, resources={r"/*": {"origins": allowed_origins}})
 


### PR DESCRIPTION
The default behaviour of the `checkHeaders` function was to block everything.
However, in a situation where all conditions are satisfied, the default behavior to block would be enacted.
This is because of the negated conditions of the `if-elif` block in `checkHeaders`

Also, the deployed API URL was not included in the allowed origins.