### PR TITLE
DOC: improving readability and auth instructions #33

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,9 +62,13 @@ The code for this repository defaults to the production environment configuratio
 
 For development purposes, you can add your localhost to the list of allowed_origins or include an authorization token in your request as documented in the two subsections below.
 
+**Note:**
+If you haven't created a new `.env` folder with the `TOKEN_KEYS`, you will recieve a `500` error when trying to submit words to check on the site.
+If keys are unauthorized it will return a `403` HTTP error.
+
 ### Allowed Origins
 
-Add the client address `http://localhost:3000` to the [allowed_origins](https://github.com/unicef/kindly/blob/7ee69561eaa53a77074b71ebcf876a8c29bb5878/api/api.py#L22), in `api/api.py`, so that it reads:
+Add the client address `http://localhost:3000` to the [allowed_origins](https://github.com/unicef/kindly/blob/7ee69561eaa53a77074b71ebcf876a8c29bb5878/api/api.py#L22), so that it reads:
 
 ```python
 allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net", "http://localhost:3000"]
@@ -73,7 +77,7 @@ allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net
 
 ### Environment Variables
 
-Alternatively, you can set Authorization headers using environment variables. This repository provides a sample template `.env.template` file in the root folder that you need to copy into a new file:
+You can set Authorization headers using environment variables. This repository provides a sample template `.env.template` file in the root folde that you need to copy into a new file. The code below will create a copy to the `.env` folder:
 
 ```bash
 cp .env.template .env
@@ -97,7 +101,7 @@ From the `api/` folder:
   source env/bin/activate
   ```
 
-2. Download a local copy of the ML model (you only have to run this the first time if `api/model` is empty):
+2. Download a local copy of the ML model (you only have to run this once):
 
   ```bash
   python get_model.py
@@ -112,12 +116,13 @@ From the `api/` folder:
 4. On a different terminal window/tab, `cd` into the client folder and and run the following command:
 
   ```bash
-  cd ../client
   npm run dev
   
   ```
 
-### Making Request with Authorization Tokens
+## Making Request with Authorization Tokens
+
+Test requests using the following 2 methods. Python server must be running and you must have an `.env` file with the `TOKEN_KEYS`.
 
 Your client HTTP requests to the API must include an `Authorization` header with a `'Bearer <token>'` value:
 


### PR DESCRIPTION
### DOC: Improving wording for instructions
- Added route for where `allowed_origins` is, as like will take to GitHub, whereas devs might be working alongside on their local. 
- Added '(you only have to run this the first time if `api/model` is empty)' for downloading ML model instructions, to make this more clear instead of just 'one time'. Also so devs know where to look for the files. And covers for edge case where someone may change their git branch and don't stash the `/model` file which then may be lost, which could cause confusion.

### DOC: improving auth section
- Made it clearer that the dev needs to also create the `.env` folder, not just update the `allowed_origins`, as without the `.env` folder the site threw a `500` error when trying to check a word. Not sure if this is a feature or a bug.
```bash
File "api.py", line 69, in checkHeaders
    tokens = json.loads(os.getenv('TOKEN_KEYS')) #this will throw an error upon request if no token keys are present in the environment at all
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```
- Included a Note under configuration explaining what errors might arise if authorisation hasn't been set up properly.
- Made ` Making Request with Authorization Tokens` a level 2 header to differentiate it from `Running locally`.
- Added more information to 'Making Request with Authorization Tokens'