### PR TITLE
MAINT: refactor env for urls and tokens

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,6 @@
 TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_1", "klasjdflkja" : "third_party_3"}'
+BEARER_TOKEN = 'a]gghrydf1234'
+BASE_URL = "http://localhost:3000" # url for frontend on local
+API_URL = "https://kindly-api.azurewebsites.net"
+ALLOWED_ORIGINS = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net"]
+PROXY_URL = 'http://localhost:8080'

--- a/api/api.py
+++ b/api/api.py
@@ -19,7 +19,7 @@ REMOTE_MAPPING = 'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/da
 
 app = Flask(__name__)
 
-allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net"]
+allowed_origins = os.getenv('ALLOWED_ORIGINS')
 
 cors = CORS(app, resources={r"/*"})
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,28 +66,33 @@ For development purposes, you can add your localhost to the list of allowed_orig
 If you haven't created a new `.env` folder with the `TOKEN_KEYS`, you will recieve a `500` error when trying to submit words to check on the site.
 If keys are unauthorized it will return a `403` HTTP error.
 
-### Allowed Origins
-
-Add the client address `http://localhost:3000` to the [allowed_origins](https://github.com/unicef/kindly/blob/7ee69561eaa53a77074b71ebcf876a8c29bb5878/api/api.py#L22), so that it reads:
-
-```python
-allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net", "http://localhost:3000"]
-
-```
 
 ### Environment Variables
 
-You can set Authorization headers using environment variables. This repository provides a sample template `.env.template` file in the root folde that you need to copy into a new file. The code below will create a copy to the `.env` folder:
+Use environment variables to set the sensitive or development specific variables needed for the project.
+This repository provides a sample template `.env.template` file in the root folder that you need to copy into a new file. The code below will create a copy to the `.env` folder:
 
 ```bash
 cp .env.template .env
 
 ```
 
+Once in your `.env` file you can update any urls, or authentication header keys if needed.
+Only change for now should be **Allowed Origins**
+
 The key used is `TOKEN_KEYS` and it is a JSON object of token keys with a value of who owns that key as seen below.
 
 ```
 TOKEN_KEYS = '{"aasdf1234":"third_party_1", "a]gghrydf1234":"third_party_1", "klasjdflkja" : "third_party_3"}'
+```
+Make sure to update the `allowed_origins` list as specified below.
+#### Allowed Origins
+
+Add the client address `http://localhost:3000` to the [allowed_origins](https://github.com/unicef/kindly/blob/7ee69561eaa53a77074b71ebcf876a8c29bb5878/api/api.py#L22), so that it reads:
+
+```python
+allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net", "http://localhost:3000"]
+
 ```
 
 ## Running Locally


### PR DESCRIPTION
Refactored the `.env.template` file to include `allowed_origins` and some urls for future separation between dev and prod.
Included relevant updates to the docs to let devs know where and how to update environment variables.