### PR TITLE
updated allowed origins list

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -19,7 +19,7 @@ REMOTE_MAPPING = 'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/da
 
 app = Flask(__name__)
 
-allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net"]
+allowed_origins = ["https://unicef.org","https://kindly-client.azurewebsites.net","https://kindly-api.azurewebsites.net","https://kindly.unicef.io"]
 
 cors = CORS(app, resources={r"/*"})
 


### PR DESCRIPTION
This PR:
- Adds  https://kindly.unicef.io to the `allowed_origins` list