### PR TITLE
MAINT: ignore *.pyc in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ api/model
 api/env
 model/
 .env
+*.pyc 


### PR DESCRIPTION
There have already been a couple of PRs that try to commit various `.pyc` files that should never be added to a repo. This PR will ignore all future such additions.