### PR TITLE
BUG: fix broken build introduced in #75

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   push_api_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push API image to Docker Hub
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 
@@ -40,7 +40,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/kindly_api:latest
 
   push_client_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push client image to Docker Hub
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 

--- a/api/api.py
+++ b/api/api.py
@@ -115,8 +115,8 @@ def process(input_text):
         labels = [row[1] for row in csvreader if len(row) > 1]
     file_path.close()
 
-    # PT
-    model = AutoModelForSequenceClassification().from_pretrained('./model')
+    # pylint: disable=no-value-for-parameter
+    model = AutoModelForSequenceClassification.from_pretrained('./model')
     # model.save_pretrained(MODEL)
     tokenizer = AutoTokenizer.from_pretrained('./model')
     encoded_input = tokenizer(preprocess(input_text), return_tensors='pt')

--- a/api/get_model.py
+++ b/api/get_model.py
@@ -4,7 +4,8 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 def get_model(model):
     """Loads model from Hugginface model hub"""
     try:
-        model = AutoModelForSequenceClassification().from_pretrained(model)
+        # pylint: disable=no-value-for-parameter
+        model = AutoModelForSequenceClassification.from_pretrained(model)
         model.save_pretrained('./model')
     except Exception as error:
         raise error

--- a/api/requirements.python-3.6.8.txt
+++ b/api/requirements.python-3.6.8.txt
@@ -10,11 +10,14 @@ matplotlib==3.3.4
 mwparserfromhell==0.6.2
 numpy==1.19.5
 pandas==1.1.5
+pre-commit == 2.15.0
+pylint == 2.11.1
 python-dotenv==0.19.0
 scikit-learn==0.24.2
 scipy==1.5.4
 tensorflow==2.6.0
 torch==1.9.0
 torchvision==0.10.0
+tokenizer==3.3.2
 transformers==4.9.1
 waitress==2.0.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,14 +10,14 @@ matplotlib==3.4.2
 mwparserfromhell==0.6.2
 numpy==1.19.5
 pandas==1.3.1
+pre-commit == 2.15.0
+pylint == 2.11.1
 python-dotenv==0.19.0
 scikit-learn==0.24.2
 scipy==1.7.0
 tensorflow==2.6.0
+tokenizer==3.3.2
 torch==1.9.0
 torchvision==0.10.0
 transformers==4.9.1
 waitress==2.0.0
-pylint == 2.11.1
-pre-commit == 2.15.0
-tokenizer==3.3.2

--- a/docs/development.md
+++ b/docs/development.md
@@ -200,15 +200,13 @@ curl \
 
 ## Setting up linting
 
-Pylint has been set up on the `api.py` and `get_model.py` 
+Pylint has been set up for all Python files in the `/api` folder. It enforces PEP8 coding standard, trying to follow it as close as possible. The pylint test can be run with the following command to check for errors:
 
-It enforces PEP8 coding standard,try to follow it as close as possible
+```bash
+pylint [file.py]
+```
 
-The pylint test can be run using `pylint [file]` command to check for errors
-
-Pylint gives information on errors and the line of codes giving errors making debugging easier
-
-Pre-commit hook has been set up to ensure that commits cannot be made if there are linting errors
+Pylint gives information on errors and their respective lines in the code to mak debugging easier. A pre-commit hook has been set up to ensure that commits cannot be made if there are linting errors.
 
 
 


### PR DESCRIPTION
* Changed `.github/workflows/main.yml` to distinguish the two workflows, otherwise one can't tell them apart when one errors out.
* Fixed a bug in the calling of `AutoModelForSequenceClassification` on both `api.py` and `get_model.py` introduced in #75 that inadvertently broke both scripts
* Propagated the changes in `requirements.txt` to `requirements.python-3.6.8.txt` introduced in #75 (plus sorted alphabetically `requirements.txt`)
* Minor edits in `docs/development.md` to improve readability