### PR TITLE
MAINT: added nltk to Python module requirements

### DIFF
--- a/api/requirements.python-3.6.8.txt
+++ b/api/requirements.python-3.6.8.txt
@@ -8,6 +8,7 @@ jupyter==1.0.0
 keras==2.6
 matplotlib==3.3.4
 mwparserfromhell==0.6.2
+nltc==3.4.5
 numpy==1.19.5
 pandas==1.1.5
 pre-commit == 2.15.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ jupyter==1.0.0
 keras==2.6
 matplotlib==3.4.2
 mwparserfromhell==0.6.2
+nltc==3.4.5
 numpy==1.19.5
 pandas==1.3.1
 pre-commit == 2.15.0


### PR DESCRIPTION
This PR complements #77 
It did not include the `nltk` library in the Jupyter Notebook file that builds the initial model.