### PR TITLE
MAINT: relaxed pylint dependencies

### DIFF
--- a/api/requirements.python-3.6.8.txt
+++ b/api/requirements.python-3.6.8.txt
@@ -14,6 +14,8 @@ pytest==6.2.5
 pytest-dotenv==0.5.2
 pre-commit == 2.15.0
 pylint == 2.11.1
+pre-commit==2.15.0
+pylint==2.10.2
 python-dotenv==0.19.0
 scikit-learn==0.24.2
 scipy==1.5.4

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,7 +13,7 @@ pandas==1.3.1
 pytest==6.2.5
 pytest-dotenv==0.5.2
 pre-commit == 2.15.0
-pylint == 2.11.1
+pylint==2.10.2
 python-dotenv==0.19.0
 scikit-learn==0.24.2
 scipy==1.7.0


### PR DESCRIPTION
Resolves the issue documented in [this comment](https://github.com/unicef/kindly/pull/61#issuecomment-949888728) from @sabinevidal by relaxing the versions locked, letting `pip` figure out the latest compatible version, and locking again to that lower version.

