### PR TITLE
BUG: remote_mapping variable wrong type

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -15,9 +15,7 @@ from waitress import serve
 
 load_dotenv()
 
-REMOTE_MAPPING = [
-    'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/datasets/offensive/mapping.txt'
-    ]
+REMOTE_MAPPING = 'https://raw.githubusercontent.com/cardiffnlp/tweeteval/main/datasets/offensive/mapping.txt'
 
 app = Flask(__name__)
 


### PR DESCRIPTION
Hi @lacabra 
Fixing a bug that was introduced in #75 I think.
`remote_mapping` a list instead of a string, failing tests on line 109 in api.py, breaking`file_path = urllib.request.urlopen(REMOTE_MAPPING)` with error 
```
 AttributeError: 'list' object has no attribute 'timeout'
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py:515: AttributeError
```