### PR TITLE
Actions/Checkout with token

### DIFF
--- a/.github/workflows/update-dataset.yml
+++ b/.github/workflows/update-dataset.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: 'Check out the repo'
       uses: 'actions/checkout@v2'
+      with:
+       token: ${{secrets.GH_ACTION_PAT}}
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Workflow still failing with protected branch permissions. Setting `actions/checkout` to use the PAT instead of default token