### PR TITLE
chore(client): dependency refresh — nuxt 2.18, vuetify 2.7, drop axios

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /api
+    schedule:
+      interval: weekly
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    groups:
+      client-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /docs-website
+    schedule:
+      interval: weekly
+    groups:
+      docs-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+open-pull-requests-limit: 5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [kindly@unicef.org](mailto:kindly@unicef.org). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Kindly
+
+Thank you for your interest in contributing to Kindly! Kindly is a UNICEF-led [digital public good](https://digitalpublicgoods.net) that aims to end cyberbullying and make students feel safer. We welcome contributions from everyone.
+
+Please take a moment to review this guide — it will help you understand our workflow and set expectations for a smooth collaboration.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Kindly Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [kindly@unicef.org](mailto:kindly@unicef.org).
+
+## How to Contribute
+
+### Reporting Issues
+
+Found a bug or have a feature request? Please [open an issue](https://github.com/unicef/kindly/issues) on GitHub. When filing an issue:
+
+- **Search existing issues** first to avoid duplicates.
+- **Use a descriptive title** that captures the problem or request.
+- **Provide steps to reproduce** bugs — include environment details (OS, browser, Python version) and any relevant logs or screenshots.
+- For feature requests, describe the use case and why it would benefit the project.
+
+### Pull Request Workflow
+
+We follow a standard fork-based workflow:
+
+1. **Fork** the [unicef/kindly](https://github.com/unicef/kindly) repository to your GitHub account.
+2. **Create a branch** from `main` with a descriptive name (e.g., `fix-typo-readme`, `feat-add-spanish-model`).
+3. **Make your changes** — keep commits focused and atomic. Write clear, concise commit messages.
+4. **Test your changes** thoroughly. If you add a feature, include tests where possible.
+5. **Push** your branch to your fork.
+6. **Open a pull request** against the `main` branch of `unicef/kindly`. In your PR description:
+   - Explain **what** you changed and **why**.
+   - Link to any related issues (e.g., `Closes #42`).
+   - Note any breaking changes or special considerations.
+7. **Review** — a maintainer will review your PR. Be responsive to feedback and be prepared to make revisions. Once approved, a maintainer will merge it.
+
+### Development Setup
+
+Refer to the [Kindly Documentation Site](https://unicef.github.io/kindly) for architecture overview, API reference, and technical development guides — including the [development setup](https://unicef.github.io/kindly/technical/development) instructions.
+
+### Pre-commit Hooks
+
+This repository uses [pre-commit](https://pre-commit.com/) to run linting and formatting checks before each commit. After cloning the repo, install the hooks with:
+
+```bash
+pre-commit install
+```
+
+This will run `pylint` on Python files automatically. You can also run all hooks manually at any time:
+
+```bash
+pre-commit run --all-files
+```
+
+## License
+
+- **Code** in this repository is licensed under the [GNU Affero General Public License v3.0](LICENSE).
+- **Data** in this repository is licensed under the [Creative Commons Attribution-ShareAlike 4.0](LICENSE.data.md).
+
+By contributing, you agree that your contributions will be licensed under these same terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Only the `main` branch is supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a security vulnerability, please report it privately via GitHub Security Advisories:
+
+**https://github.com/unicef/kindly/security/advisories/new**
+
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+## Response Timeline
+
+We aim to acknowledge receipt of your report within **5 business days**. We will keep you updated on our progress and coordinate disclosure with you.
+
+## Code of Conduct
+
+Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before reporting. All reporters are expected to adhere to it.
+
+---
+
+> **Note:** This is a UNICEF Digital Public Good. Please act responsibly and in accordance with our Code of Conduct.


### PR DESCRIPTION
## Summary

- Nuxt 2.15 → 2.18.1 (final Nuxt 2 release)
- Vuetify 2.5 → 2.7 (latest non-breaking)
- Removed stale direct axios dependency (unused; only @nuxtjs/axios needed)
- Fresh lockfile

Addresses Nuxt XSS/open-redirect + axios credential-leak clusters.

Notes: Nuxt 2 is EOL; migration to Nuxt 3 is a roadmap item. Dev-only transitive alerts remaining are documented.